### PR TITLE
ci: refactor Makefile. improve linter setup. upgrade deps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,7 +15,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: build
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       image: golang:latest
     steps:
       - name: clone
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: tags
         run: |

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v1
@@ -30,7 +30,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: test
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
       image: golang:latest
     steps:
     - name: clone
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: validate
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,3 +24,5 @@ jobs:
         go vet ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
         # Check that go fmt ./... produces a zero diff; clean up any changes afterwards.
         go fmt ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
+        # Check that go fix ./... produces a zero diff; clean up any changes afterwards.
+        go fix ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,14 +2,64 @@
 # some defaults explicitly provided. There is a large number of
 # linters we've enabled that are usually disabled by default.
 #
-# https://github.com/golangci/golangci-lint#config-file
+# https://golangci-lint.run/usage/configuration/#config-file
 
 # This section provides the configuration for how golangci
 # outputs it results from the linters it executes.
 output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number
+
+  # print lines of code with issue, default is true
   print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
   print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+# This section provides the configuration for each linter
+# we've instructed golangci to execute.
+linters-settings:
+  # https://github.com/mibk/dupl
+  dupl:
+    threshold: 100
+
+  # https://github.com/ultraware/funlen
+  funlen:
+    lines: 100
+    statements: 50
+
+  # https://github.com/golang/lint
+  golint:
+    min-confidence: 0
+
+  # https://github.com/tommy-muehle/go-mnd
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+
+  # https://github.com/walle/lll
+  lll:
+    line-length: 100
+
+  # https://github.com/mdempsky/maligned
+  maligned:
+    suggest-new: true
+
+  # https://github.com/client9/misspell
+  misspell:
+    locale: US
+
+  # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -17,57 +67,71 @@ output:
 linters:
   # disable all linters as new linters might be added to golangci
   disable-all: true
-  enable:
-    # linters enabled by default
-    - deadcode
-    - errcheck
-    - govet
-    - gosimple # a.k.a. megacheck
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
 
-    # linters disabled by default
+  # enable a specific set of linters to run
+  enable:
     - bodyclose
-    - gocognit
+    - deadcode # enabled by default
+    - dupl
+    - errcheck # enabled by default
+    - funlen
     - goconst
     - gocyclo
+    - godot
+    - gofmt
     - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
     - gosec
-    - funlen
+    - gosimple # enabled by default
+    - govet # enabled by default
+    - ineffassign # enabled by default
+    - lll
     - maligned
     - misspell
+    - nakedret
+    - nolintlint
+    - staticcheck # enabled by default
+    - structcheck # enabled by default
     - stylecheck
+    - typecheck # enabled by default
+    - unconvert
     - unparam
+    - unused # enabled by default
+    - varcheck # enabled by default
     - whitespace
-    - wsl
 
   # static list of linters we know golangci can run but we've
   # chosen to leave disabled for now
-  #
-  # disable:
-  #   - depguard
-  #   - dogsled
-  #   - dupl
-  #   - gocritic
-  #   - gochecknoinits
-  #   - gochecknoglobals
-  #   - godox
-  #   - gofmt
-  #   - golint
-  #   - gomnd
-  #   - interfacer
-  #   - lll
-  #   - nakedret
-  #   - scopelint
-  #   - unconvert
+  # - asciicheck
+  # - depguard
+  # - dogsled
+  # - exhaustive
+  # - gochecknoinits
+  # - gochecknoglobals
+  # - gocognit
+  # - gocritic
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - nestif
+  # - noctx
+  # - prealloc
+  # - rowserrcheck
+  # - scopelint
+  # - testpackage
+  # - wsl
 
-# This section provides the configuration for each linter
-# we've instructed golangci to execute.
-linters-settings:
-  funlen:
-    lines: 100
-    statements: 60
+# This section provides the configuration for how golangci
+# will report the issues it finds.
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # prevent linters from running on *_test.go files
+    - path: _test\.go
+      linters:
+        - funlen
+        - goconst
+        - gocyclo
+        - gomnd

--- a/Makefile
+++ b/Makefile
@@ -2,65 +2,207 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
-.PHONY: build
-build: binary-build
+# The `clean` target is intended to clean the workspace
+# and prepare the local changes for submission.
+#
+# Usage: `make clean`
+.PHONY: clean
+clean: tidy vet fmt fix
 
+# The `run` target is intended to build and
+# execute the Docker image for the plugin.
+#
+# Usage: `make run`
 .PHONY: run
 run: build docker-build docker-run
 
-.PHONY: test
-test: build docker-build docker-example
-
-#################################
-######      Go clean       ######
-#################################
-
-.PHONY: clean
-clean:
-
+# The `tidy` target is intended to clean up
+# the Go module files (go.mod & go.sum).
+#
+# Usage: `make tidy`
+.PHONY: tidy
+tidy:
+	@echo
+	@echo "### Tidying Go module"
 	@go mod tidy
+
+# The `vet` target is intended to inspect the
+# Go source code for potential issues.
+#
+# Usage: `make vet`
+.PHONY: vet
+vet:
+	@echo
+	@echo "### Vetting Go code"
 	@go vet ./...
+
+# The `fmt` target is intended to format the
+# Go source code to meet the language standards.
+#
+# Usage: `make fmt`
+.PHONY: fmt
+fmt:
+	@echo
+	@echo "### Formatting Go Code"
 	@go fmt ./...
-	@echo "I'm kind of the only name in clean energy right now"
 
-#################################
-######    Build Binary     ######
-#################################
+# The `fix` target is intended to rewrite the
+# Go source code using old APIs.
+#
+# Usage: `make fix`
+.PHONY: fix
+fix:
+	@echo
+	@echo "### Fixing Go Code"
+	@go fix ./...
 
-.PHONY: binary-build
-binary-build:
+# The `test` target is intended to run
+# the tests for the Go source code.
+#
+# Usage: `make test`
+.PHONY: test
+test:
+	@echo
+	@echo "### Testing Go Code"
+	@go test -race ./...
 
-	GOOS=linux CGO_ENABLED=0 go build -o release/vela-downstream github.com/go-vela/vela-downstream/cmd/vela-downstream
+# The `test-cover` target is intended to run
+# the tests for the Go source code and then
+# open the test coverage report.
+#
+# Usage: `make test-cover`
+.PHONY: test-cover
+test-cover:
+	@echo
+	@echo "### Creating test coverage report"
+	@go test -race -covermode=atomic -coverprofile=coverage.out ./...
+	@echo
+	@echo "### Opening test coverage report"
+	@go tool cover -html=coverage.out
 
-#################################
-######    Docker Build     ######
-#################################
+# The `build` target is intended to compile
+# the Go source code into a binary.
+#
+# Usage: `make build`
+.PHONY: build
+build:
+	@echo
+	@echo "### Building release/vela-downstream binary"
+	GOOS=linux CGO_ENABLED=0 \
+		go build -a \
+		-o release/vela-downstream \
+		github.com/go-vela/vela-downstream/cmd/vela-downstream
 
+# The `build-static` target is intended to compile
+# the Go source code into a statically linked binary.
+#
+# Usage: `make build-static`
+.PHONY: build-static
+build-static:
+	@echo
+	@echo "### Building static release/vela-downstream binary"
+	GOOS=linux CGO_ENABLED=0 \
+		go build -a \
+		-ldflags '-s -w -extldflags "-static"' \
+		-o release/vela-downstream \
+		github.com/go-vela/vela-downstream/cmd/vela-downstream
+
+# The `check` target is intended to output all
+# dependencies from the Go module that need updates.
+#
+# Usage: `make check`
+.PHONY: check
+check: check-install
+	@echo
+	@echo "### Checking dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated -update
+
+# The `check-direct` target is intended to output direct
+# dependencies from the Go module that need updates.
+#
+# Usage: `make check-direct`
+.PHONY: check-direct
+check-direct: check-install
+	@echo
+	@echo "### Checking direct dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated -direct
+
+# The `check-full` target is intended to output
+# all dependencies from the Go module.
+#
+# Usage: `make check-full`
+.PHONY: check-full
+check-full: check-install
+	@echo
+	@echo "### Checking all dependencies for updates"
+	@go list -u -m -json all | go-mod-outdated
+
+# The `check-install` target is intended to download
+# the tool used to check dependencies from the Go module.
+#
+# Usage: `make check-install`
+.PHONY: check-install
+check-install:
+	@echo
+	@echo "### Installing psampaz/go-mod-outdated"
+	@go get -u github.com/psampaz/go-mod-outdated
+
+# The `bump-deps` target is intended to upgrade
+# non-test dependencies for the Go module.
+#
+# Usage: `make bump-deps`
+.PHONY: bump-deps
+bump-deps: check
+	@echo
+	@echo "### Upgrading dependencies"
+	@go get -u ./...
+
+# The `bump-deps-full` target is intended to upgrade
+# all dependencies for the Go module.
+#
+# Usage: `make bump-deps-full`
+.PHONY: bump-deps-full
+bump-deps-full: check
+	@echo
+	@echo "### Upgrading all dependencies"
+	@go get -t -u ./...
+
+# The `docker-build` target is intended to build
+# the Docker image for the plugin.
+#
+# Usage: `make docker-build`
 .PHONY: docker-build
 docker-build:
+	@echo
+	@echo "### Building vela-downstream:local image"
+	@docker build --no-cache -t vela-downstream:local .
 
-	docker build --no-cache -t vela-artifactory:local .
+# The `docker-test` target is intended to execute
+# the Docker image for the plugin with test variables.
+#
+# Usage: `make docker-test`
+.PHONY: docker-test
+docker-test:
+	@echo
+	@echo "### Testing vela-downstream:local image"
+	@docker run --rm \
+		-e DOWNSTREAM_SERVER \
+		-e DOWNSTREAM_TOKEN \
+		-e PARAMETER_REPOS \
+		vela-downstream:local
 
-#################################
-######     Docker Run      ######
-#################################
-
+# The `docker-run` target is intended to execute
+# the Docker image for the plugin.
+#
+# Usage: `make docker-run`
 .PHONY: docker-run
 docker-run:
-
-	docker run --rm \
+	@echo
+	@echo "### Executing vela-downstream:local image"
+	@docker run --rm \
 		-e DOWNSTREAM_SERVER \
 		-e DOWNSTREAM_TOKEN \
 		-e PARAMETER_LOG_LEVEL \
 		-e PARAMETER_BRANCH \
-		-e PARAMETER_REPOS \
-		vela-downstream:local
-
-.PHONY: docker-example
-docker-example:
-
-	docker run --rm \
-		-e DOWNSTREAM_SERVER \
-		-e DOWNSTREAM_TOKEN \
 		-e PARAMETER_REPOS \
 		vela-downstream:local

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,20 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
+.PHONY: build
 build: binary-build
 
+.PHONY: run
 run: build docker-build docker-run
 
+.PHONY: test
 test: build docker-build docker-example
 
 #################################
 ######      Go clean       ######
 #################################
 
+.PHONY: clean
 clean:
 
 	@go mod tidy
@@ -23,6 +27,7 @@ clean:
 ######    Build Binary     ######
 #################################
 
+.PHONY: binary-build
 binary-build:
 
 	GOOS=linux CGO_ENABLED=0 go build -o release/vela-downstream github.com/go-vela/vela-downstream/cmd/vela-downstream
@@ -31,14 +36,16 @@ binary-build:
 ######    Docker Build     ######
 #################################
 
+.PHONY: docker-build
 docker-build:
 
-	docker build --no-cache -t vela-downstream:local .
+	docker build --no-cache -t vela-artifactory:local .
 
 #################################
 ######     Docker Run      ######
 #################################
 
+.PHONY: docker-run
 docker-run:
 
 	docker run --rm \
@@ -49,6 +56,7 @@ docker-run:
 		-e PARAMETER_REPOS \
 		vela-downstream:local
 
+.PHONY: docker-example
 docker-example:
 
 	docker run --rm \

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,10 +20,17 @@ coverage:
   round: down
   range: "70...100"
 
+  # https://docs.codecov.io/docs/commit-status
   status:
-    project: yes
-    patch: yes
-    changes: no
+    # set rules for the project status report
+    project:
+      default:
+        target: 90%
+        threshold: 0%
+    # disable the patch status report
+    patch: off
+    # disable the changes status report
+    changes: off
 
 # This section provides the configuration for the
 # parsers codecov uses for the coverage report.

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/go-vela/vela-downstream
 go 1.13
 
 require (
-	github.com/go-vela/sdk-go v0.4.0
-	github.com/go-vela/types v0.4.0
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/go-vela/sdk-go v0.4.3
+	github.com/go-vela/types v0.4.3
 	github.com/joho/godotenv v1.3.0
-	github.com/sirupsen/logrus v1.5.0
+	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli/v2 v2.2.0
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
+github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -31,12 +33,12 @@ github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTM
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
-github.com/go-vela/mock v0.4.0 h1:dsGhJHDbM/4FibLqCdHsUV+oADEqht1I+dlA5oa6ADU=
-github.com/go-vela/mock v0.4.0/go.mod h1:rYOHTgSHhYPbgn/4h5N7cIOmRpH5XogLbCz3FyW+Xv0=
-github.com/go-vela/sdk-go v0.4.0 h1:exnNeImHmvLBgTwp7tWtqjH0rh9G1GISJR1RFGomKTQ=
-github.com/go-vela/sdk-go v0.4.0/go.mod h1:jhG5Hu7+3ka4P2avfmnyNZQ5SeYPh6BGlNi9enht8FI=
-github.com/go-vela/types v0.4.0 h1:g2CceYM78QYJ3AbnPpSFoELTw3Ll+tAgoyFGyr2YGoU=
-github.com/go-vela/types v0.4.0/go.mod h1:ig7fC+MKGsgAlKqovkFsUQlbZtLDLhl/djiedHmsL5s=
+github.com/go-vela/mock v0.4.3 h1:Ts60thJEd8lkrC7ulvSxoT8p0sL+/38DtwiAB0XI1y8=
+github.com/go-vela/mock v0.4.3/go.mod h1:0jefMm79gmAiHt2vlYwHrZX3TUeHK8ktQzGgM2Tvi9M=
+github.com/go-vela/sdk-go v0.4.3 h1:+mfDcwSCLlM2tn1HIq1jOgJnJ2nkoaucWd5wTgfddsM=
+github.com/go-vela/sdk-go v0.4.3/go.mod h1:rhbY07rm6SaesHzzvS5SvWYDFGbGi4ESnB2frVhENwk=
+github.com/go-vela/types v0.4.3 h1:AMAbCyaoLCPAlxgae4myCKJQq1xIvc9hy+nCEL6l/+E=
+github.com/go-vela/types v0.4.3/go.mod h1:ig7fC+MKGsgAlKqovkFsUQlbZtLDLhl/djiedHmsL5s=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -59,6 +61,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -87,6 +91,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
@@ -123,6 +129,8 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab h1:FvshnhkKW+LO3HWHodML8kuVX8rnJTxKm9dFPuI68UM=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -150,8 +158,8 @@ gopkg.in/go-playground/validator.v9 v9.30.2/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWd
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
* Add `.PHONY` tags to Makefile
* Add new `make` targets for upgrading dependencies
* Skip the `patch` status from codecov.io
* Add more linters to `golangci-lint`
* Update linter settings for `golangci-lint`
* Skip execution of some `golangci-lint` linters on Go test files
* Upgrade `actions/checkout` workflow to `v2`
* Add `go fix` to `validate` Action workflow
* Upgrade go module dependencies