### PR TITLE
feat(plugin)!: build reporting and other enhancements

### DIFF
--- a/.vela/template.yml
+++ b/.vela/template.yml
@@ -5,7 +5,7 @@
 # - .pull      (default: true)
 # - .log_level (default: "info")
 # - .server:   (default: "")
-# - .branch:   (default: "master")
+# - .branch:   (default: "main")
 # - .repos:    (default: "[]")
 
 metadata:
@@ -18,5 +18,5 @@ steps:
     parameters:
       log_level: {{ default "info" .log_level }}
       server: {{ default "" .server }}
-      branch: {{ default "master" .branch }}
+      branch: {{ default "main" .branch }}
       repos: {{ default "[]" .repos }}

--- a/DOCS.md
+++ b/DOCS.md
@@ -172,6 +172,7 @@ The following parameters are used to configure the image:
 
 | Name                    | Description                                           | Required | Default       | Environment Variables                                 |
 | ----------------------- | ---------------------------------------------------- | -------- | ------------- | ---------------------------------------------------- |
+| `branch`                | branch to trigger a build on                          | `false`  | `N/A`         | `PARAMETER_BRANCH`<br>`DOWNSTREAM_BRANCH`       |
 | `event`                 | event to trigger a build on                           | `true`   | `push`        | `PARAMETER_EVENT`<br>`DOWNSTREAM_EVENT`               |
 | `log_level`             | set the log level for the plugin                      | `true`   | `info`        | `PARAMETER_LOG_LEVEL`<br>`DOWNSTREAM_LOG_LEVEL`       |
 | `repos`                 | list of <org>/<repo> names to trigger a build on      | `true`   | `N/A`         | `PARAMETER_REPOS`<br>`DOWNSTREAM_REPOS`               |

--- a/DOCS.md
+++ b/DOCS.md
@@ -170,15 +170,18 @@ steps:
 
 The following parameters are used to configure the image:
 
-| Name        | Description                                      | Required | Default       | Environment Variables                           |
-| ----------- | ------------------------------------------------ | -------- | ------------- | ----------------------------------------------- |
-| `branch`    | branch to trigger a build on                     | `true`   | `master`      | `PARAMETER_BRANCH`<br>`DOWNSTREAM_BRANCH`       |
-| `event`     | event to trigger a build on                      | `true`   | `push`        | `PARAMETER_EVENT`<br>`DOWNSTREAM_EVENT`         |
-| `log_level` | set the log level for the plugin                 | `true`   | `info`        | `PARAMETER_LOG_LEVEL`<br>`DOWNSTREAM_LOG_LEVEL` |
-| `repos`     | list of <org>/<repo> names to trigger a build on | `true`   | `N/A`         | `PARAMETER_REPOS`<br>`DOWNSTREAM_REPOS`         |
-| `server`    | Vela server to communicate with                  | `true`   | `N/A`         | `PARAMETER_SERVER`<br>`DOWNSTREAM_SERVER`       |
-| `status`    | list of statuses to trigger a build on           | `true`   | `[ success ]` | `PARAMETER_STATUS`<br>`DOWNSTREAM_STATUS`       |
-| `token`     | token for communication with Vela                | `true`   | `N/A`         | `PARAMETER_TOKEN`<br>`DOWNSTREAM_TOKEN`         |
+| Name                    | Description                                           | Required | Default       | Environment Variables                                 |
+| ----------------------- | ---------------------------------------------------- | -------- | ------------- | ---------------------------------------------------- |
+| `event`                 | event to trigger a build on                           | `true`   | `push`        | `PARAMETER_EVENT`<br>`DOWNSTREAM_EVENT`               |
+| `log_level`             | set the log level for the plugin                      | `true`   | `info`        | `PARAMETER_LOG_LEVEL`<br>`DOWNSTREAM_LOG_LEVEL`       |
+| `repos`                 | list of <org>/<repo> names to trigger a build on      | `true`   | `N/A`         | `PARAMETER_REPOS`<br>`DOWNSTREAM_REPOS`               |
+| `server`                | Vela server to communicate with                       | `true`   | `N/A`         | `PARAMETER_SERVER`<br>`DOWNSTREAM_SERVER`             |
+| `status`                | list of statuses to trigger a build on                | `true`   | `[ success ]` | `PARAMETER_STATUS`<br>`DOWNSTREAM_STATUS`             |
+| `token`                 | token for communication with Vela                     | `true`   | `N/A`         | `PARAMETER_TOKEN`<br>`DOWNSTREAM_TOKEN`               |
+| `report_back`           | whether or not to track downstream build status       | `false`  | `false`       | `PARAMETER_REPORT_BACK`<br>`DOWNSTREAM_REPORT_BACK`   |
+| `target_status`         | list of statuses to look for from downstream builds   | `false`  | `[ success ]` | `PARAMETER_TARGET_STATUS`<br>`DOWNSTREAM_TARGET_STATUS` |
+| `timeout`               | how long should the plugin wait for downstream builds | `false`  | `30m`         | `PARAMETER_TIMEOUT`<br>`DOWNSTREAM_TIMEOUT`             |
+| `continue_on_not_found` | continue triggering builds on failure to find one     | `false`  | `false`       | `PARAMETER_CONTINUE_ON_NOT_FOUND`<br>`DOWNSTREAM_CONTINUE_ON_NOT_FOUND` |
 
 ## Template
 

--- a/cmd/vela-downstream/build_test.go
+++ b/cmd/vela-downstream/build_test.go
@@ -12,7 +12,7 @@ import (
 func TestDownstream_Build_Validate(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch: "master",
+		Branch: "main",
 		Event:  constants.EventPush,
 		Status: []string{constants.StatusSuccess},
 	}
@@ -41,7 +41,7 @@ func TestDownstream_Build_Validate_NoBranch(t *testing.T) {
 func TestDownstream_Build_Validate_NoEvent(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch: "master",
+		Branch: "main",
 		Status: []string{constants.StatusSuccess},
 	}
 
@@ -55,7 +55,7 @@ func TestDownstream_Build_Validate_NoEvent(t *testing.T) {
 func TestDownstream_Build_Validate_NoStatus(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch: "master",
+		Branch: "main",
 		Event:  constants.EventPush,
 	}
 
@@ -69,7 +69,7 @@ func TestDownstream_Build_Validate_NoStatus(t *testing.T) {
 func TestDownstream_Build_Validate_InvalidEvent(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch: "master",
+		Branch: "main",
 		Event:  "foo",
 		Status: []string{constants.StatusSuccess},
 	}
@@ -84,7 +84,7 @@ func TestDownstream_Build_Validate_InvalidEvent(t *testing.T) {
 func TestDownstream_Build_Validate_InvalidStatus(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch: "master",
+		Branch: "main",
 		Event:  constants.EventPush,
 		Status: []string{"foo"},
 	}
@@ -99,7 +99,7 @@ func TestDownstream_Build_Validate_InvalidStatus(t *testing.T) {
 func TestDownstream_Build_Validate_HighTimeout(t *testing.T) {
 	// setup types
 	b := &Build{
-		Branch:  "master",
+		Branch:  "main",
 		Event:   constants.EventPush,
 		Status:  []string{"success"},
 		Timeout: 120 * time.Minute,

--- a/cmd/vela-downstream/build_test.go
+++ b/cmd/vela-downstream/build_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-vela/types/constants"
 )
@@ -32,8 +33,8 @@ func TestDownstream_Build_Validate_NoBranch(t *testing.T) {
 
 	// run test
 	err := b.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+	if err != nil {
+		t.Errorf("Validate should not have returned err")
 	}
 }
 
@@ -92,5 +93,24 @@ func TestDownstream_Build_Validate_InvalidStatus(t *testing.T) {
 	err := b.Validate()
 	if err == nil {
 		t.Errorf("Validate should have returned err")
+	}
+}
+
+func TestDownstream_Build_Validate_HighTimeout(t *testing.T) {
+	// setup types
+	b := &Build{
+		Branch:  "master",
+		Event:   constants.EventPush,
+		Status:  []string{"success"},
+		Timeout: 120 * time.Minute,
+	}
+
+	err := b.Validate()
+	if err != nil {
+		t.Errorf("Validate returned an error")
+	}
+
+	if b.Timeout != (90 * time.Minute) {
+		t.Errorf("Validate should have a timeout of max 90 minutes")
 	}
 }

--- a/cmd/vela-downstream/main.go
+++ b/cmd/vela-downstream/main.go
@@ -72,7 +72,6 @@ func main() {
 			FilePath: "/vela/parameters/downstream/branch,/vela/secrets/downstream/branch",
 			Name:     "build.branch",
 			Usage:    "branch to trigger a build for the repo",
-			Value:    "master",
 		},
 		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_EVENT", "DOWNSTREAM_EVENT"},
@@ -86,6 +85,35 @@ func main() {
 			FilePath: "/vela/parameters/downstream/status,/vela/secrets/downstream/status",
 			Name:     "build.status",
 			Usage:    "list of statuses to trigger a build for the repo",
+			Value:    cli.NewStringSlice(constants.StatusSuccess),
+		},
+		&cli.BoolFlag{
+			EnvVars:  []string{"PARAMETER_CONTINUE_ON_NOT_FOUND", "DOWNSTREAM_CONTINUE_ON_NOT_FOUND"},
+			FilePath: "/vela/parameters/downstream/report_back,/vela/secrets/downstream/report_back",
+			Name:     "build.continue",
+			Usage:    "determine whether the downstream plugin should continue through repo list if a build is not found to restart",
+		},
+
+		// Build Check Flags
+
+		&cli.BoolFlag{
+			EnvVars:  []string{"PARAMETER_REPORT_BACK", "DOWNSTREAM_REPORT_BACK"},
+			FilePath: "/vela/parameters/downstream/report_back,/vela/secrets/downstream/report_back",
+			Name:     "build-check.enabled",
+			Usage:    "determine whether the downstream plugin should wait for its triggered builds and report their statuses",
+		},
+		&cli.DurationFlag{
+			EnvVars:  []string{"PARAMETER_TIMEOUT", "DOWNSTREAM_TIMEOUT"},
+			FilePath: "/vela/parameters/downstream/timeout,/vela/secrets/downstream/timeout",
+			Name:     "build-check.timeout",
+			Usage:    "timeout for checking on triggered build statuses",
+			Value:    30 * time.Minute,
+		},
+		&cli.StringSliceFlag{
+			EnvVars:  []string{"PARAMETER_TARGET_STATUS", "DOWNSTREAM_TARGET_STATUS"},
+			FilePath: "/vela/parameters/downstream/target_status,/vela/secrets/downstream/target_status",
+			Name:     "build-check.status",
+			Usage:    "list of statuses that constitute a successful triggered build",
 			Value:    cli.NewStringSlice(constants.StatusSuccess),
 		},
 
@@ -152,9 +180,13 @@ func run(c *cli.Context) error {
 	p := &Plugin{
 		// build configuration
 		Build: &Build{
-			Branch: c.String("build.branch"),
-			Event:  c.String("build.event"),
-			Status: c.StringSlice("build.status"),
+			Branch:       c.String("build.branch"),
+			Event:        c.String("build.event"),
+			Status:       c.StringSlice("build.status"),
+			Report:       c.Bool("build-check.enabled"),
+			TargetStatus: c.StringSlice("build-check.status"),
+			Timeout:      c.Duration("build-check.timeout"),
+			Continue:     c.Bool("build.continue"),
 		},
 		// config configuration
 		Config: &Config{

--- a/cmd/vela-downstream/plugin_test.go
+++ b/cmd/vela-downstream/plugin_test.go
@@ -12,7 +12,7 @@ func TestDownstream_Plugin_Exec_Error(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Branch: "master",
+			Branch: "main",
 			Event:  constants.EventPush,
 			Status: []string{constants.StatusSuccess},
 		},
@@ -21,7 +21,7 @@ func TestDownstream_Plugin_Exec_Error(t *testing.T) {
 			Token:  "superSecretVelaToken",
 		},
 		Repo: &Repo{
-			Names: []string{"go-vela/hello-world@master"},
+			Names: []string{"go-vela/hello-world@main"},
 		},
 	}
 
@@ -35,7 +35,7 @@ func TestDownstream_Plugin_Validate(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Branch: "master",
+			Branch: "main",
 			Event:  constants.EventPush,
 			Status: []string{constants.StatusSuccess},
 		},
@@ -44,7 +44,7 @@ func TestDownstream_Plugin_Validate(t *testing.T) {
 			Token:  "superSecretVelaToken",
 		},
 		Repo: &Repo{
-			Names: []string{"go-vela/hello-world@master"},
+			Names: []string{"go-vela/hello-world@main"},
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestDownstream_Plugin_Validate_NoBuild(t *testing.T) {
 			Token:  "superSecretVelaToken",
 		},
 		Repo: &Repo{
-			Names: []string{"go-vela/hello-world@master"},
+			Names: []string{"go-vela/hello-world@main"},
 		},
 	}
 
@@ -77,13 +77,13 @@ func TestDownstream_Plugin_Validate_NoConfig(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Branch: "master",
+			Branch: "main",
 			Event:  constants.EventPush,
 			Status: []string{constants.StatusSuccess},
 		},
 		Config: &Config{},
 		Repo: &Repo{
-			Names: []string{"go-vela/hello-world@master"},
+			Names: []string{"go-vela/hello-world@main"},
 		},
 	}
 
@@ -97,7 +97,7 @@ func TestDownstream_Plugin_Validate_NoRepo(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Branch: "master",
+			Branch: "main",
 			Event:  constants.EventPush,
 			Status: []string{constants.StatusSuccess},
 		},

--- a/cmd/vela-downstream/repo_test.go
+++ b/cmd/vela-downstream/repo_test.go
@@ -25,12 +25,12 @@ func TestDownstream_Repo_Parse(t *testing.T) {
 	r2.SetOrg("go-vela")
 	r2.SetName("hello-world")
 	r2.SetFullName("go-vela/hello-world")
-	r2.SetBranch("master")
+	r2.SetBranch("main")
 
 	want := []*library.Repo{r1, r2}
 
 	// run test
-	got, err := r.Parse("master")
+	got, err := r.Parse("main")
 	if err != nil {
 		t.Errorf("Parse returned err: %v", err)
 	}
@@ -43,11 +43,11 @@ func TestDownstream_Repo_Parse(t *testing.T) {
 func TestDownstream_Repo_Parse_MultipleSlashes(t *testing.T) {
 	// setup types
 	r := &Repo{
-		Names: []string{"go-vela/hello-world/master"},
+		Names: []string{"go-vela/hello-world/main"},
 	}
 
 	// run test
-	got, err := r.Parse("master")
+	got, err := r.Parse("main")
 	if err == nil {
 		t.Errorf("Parse should have returned err")
 	}
@@ -60,11 +60,11 @@ func TestDownstream_Repo_Parse_MultipleSlashes(t *testing.T) {
 func TestDownstream_Repo_Parse_MultipleAtSigns(t *testing.T) {
 	// setup types
 	r := &Repo{
-		Names: []string{"go-vela/hello-world@master@"},
+		Names: []string{"go-vela/hello-world@main@"},
 	}
 
 	// run test
-	got, err := r.Parse("master")
+	got, err := r.Parse("main")
 	if err == nil {
 		t.Errorf("Parse should have returned err")
 	}
@@ -77,7 +77,7 @@ func TestDownstream_Repo_Parse_MultipleAtSigns(t *testing.T) {
 func TestDownstream_Repo_Validate(t *testing.T) {
 	// setup types
 	r := &Repo{
-		Names: []string{"go-vela/hello-world@master"},
+		Names: []string{"go-vela/hello-world@main"},
 	}
 
 	err := r.Validate()
@@ -113,7 +113,7 @@ func TestDownstream_Repo_Validate_NoSlash(t *testing.T) {
 func TestDownstream_Repo_Validate_MultipleSlashes(t *testing.T) {
 	// setup types
 	r := &Repo{
-		Names: []string{"go-vela/hello-world/master"},
+		Names: []string{"go-vela/hello-world/main"},
 	}
 
 	// run test


### PR DESCRIPTION
A few things in this PR...

### Reporting
The major thing is the addition of the `Report(...)` method, which will run whenever the user specifies

```yaml
  - name: downstream
    image: target/vela-downstream:latest
    secrets: [ downstream_token ]
    parameters:
      report_back: true
```

This will cause the plugin to enter a timeout loop (default 30 minutes), where every 30 seconds it will check the statuses of all the builds that were kicked off as a result of the plugin.

The extra parameters for that are as follows:

```yaml
  - name: downstream
    image: target/vela-downstream:latest
    secrets: [ downstream_token ]
    parameters:
      report_back: true # default of `false`
      target_status: [ success, canceled ] # default of `success`
      timeout: 60m # default of `30m`
```

### No More Branch Default

I updated the SDK call to

```go
opts := &vela.BuildListOptions{
	Branch: repo.GetBranch(),
	Event:  p.Build.Event,
	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela#ListOptions
	ListOptions: vela.ListOptions{
		// set the default starting page for options
		Page: 1,
		// set the max per page for options
		PerPage: 100,
	},
}
```

And removed the default injection of `master` for the branch, hence the breaking change designation. Not only is this a dated default value, but having any default value at all causes some cognitive dissonance when thinking about events such as `comment` and even `tag` as we've found.

### Continuing through repos option

Using the `continue_on_not_found` tag will not stop the plugin from kicking off builds from other repos. The need for such a tag is debatable, but it's definitely not a big deal to have it as an option.

```yaml
  - name: downstream
    image: target/vela-downstream:latest
    secrets: [ downstream_token ]
    parameters:
      continue_on_not_found: true
      repos: [ repoA, repoB, repoC ]
```
