### PR TITLE
enhance: any status, error wrapping, and fetch improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@eb055d739abdc2e8de2e5f4ba1a8b246daa779aa # v3.26.0
+      uses: github/codeql-action/init@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@eb055d739abdc2e8de2e5f4ba1a8b246daa779aa # v3.26.0
+      uses: github/codeql-action/autobuild@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@eb055d739abdc2e8de2e5f4ba1a8b246daa779aa # v3.26.0
+      uses: github/codeql-action/analyze@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3

--- a/cmd/vela-downstream/build.go
+++ b/cmd/vela-downstream/build.go
@@ -79,6 +79,7 @@ func (b *Build) Validate() error {
 		constants.StatusPending,
 		constants.StatusRunning,
 		constants.StatusSuccess,
+		"any",
 	}
 
 	// iterate through the build statuses provided

--- a/cmd/vela-downstream/config.go
+++ b/cmd/vela-downstream/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	Server string
 	// user token to authenticate with the Vela server
 	Token string
+	// depth of builds search in downstream repo
+	Depth int
 	// the app name utilizing this config
 	AppName string
 	// the app version utilizing this config

--- a/cmd/vela-downstream/main.go
+++ b/cmd/vela-downstream/main.go
@@ -131,6 +131,13 @@ func main() {
 			Name:     "config.token",
 			Usage:    "user token to authenticate with the Vela server",
 		},
+		&cli.IntFlag{
+			EnvVars:  []string{"PARAMETER_DEPTH", "DOWNSTREAM_DEPTH"},
+			FilePath: "/vela/parameters/downstream/depth,/vela/secrets/downstream/depth",
+			Name:     "config.depth",
+			Usage:    "number of builds to search for downstream repositories",
+			Value:    50,
+		},
 
 		// Repo Flags
 
@@ -192,6 +199,7 @@ func run(c *cli.Context) error {
 		Config: &Config{
 			Server:     c.String("config.server"),
 			Token:      c.String("config.token"),
+			Depth:      c.Int("config.depth"),
 			AppName:    c.App.Name,
 			AppVersion: c.App.Version,
 		},

--- a/cmd/vela-downstream/repo.go
+++ b/cmd/vela-downstream/repo.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 
 	"github.com/sirupsen/logrus"
 )
@@ -18,17 +18,17 @@ type Repo struct {
 }
 
 // Parse verifies the Repo is properly configured.
-func (r *Repo) Parse(branch string) ([]*library.Repo, error) {
+func (r *Repo) Parse(branch string) ([]*api.Repo, error) {
 	logrus.Trace("parsing repos from provided configuration")
 
 	// create new repos type to store parsed repos
-	repos := []*library.Repo{}
+	repos := []*api.Repo{}
 
 	for _, name := range r.Names {
 		logrus.Tracef("parsing repo %s", name)
 
 		// create new repo type to store parsed repo information
-		repo := new(library.Repo)
+		repo := new(api.Repo)
 
 		// split the repo on / to account for org/repo as input
 		parts := strings.Split(name, "/")

--- a/cmd/vela-downstream/repo_test.go
+++ b/cmd/vela-downstream/repo_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 func TestDownstream_Repo_Parse(t *testing.T) {
@@ -15,19 +15,19 @@ func TestDownstream_Repo_Parse(t *testing.T) {
 		Names: []string{"go-vela/hello-world@test", "go-vela/hello-world"},
 	}
 
-	r1 := new(library.Repo)
+	r1 := new(api.Repo)
 	r1.SetOrg("go-vela")
 	r1.SetName("hello-world")
 	r1.SetFullName("go-vela/hello-world")
 	r1.SetBranch("test")
 
-	r2 := new(library.Repo)
+	r2 := new(api.Repo)
 	r2.SetOrg("go-vela")
 	r2.SetName("hello-world")
 	r2.SetFullName("go-vela/hello-world")
 	r2.SetBranch("main")
 
-	want := []*library.Repo{r1, r2}
+	want := []*api.Repo{r1, r2}
 
 	// run test
 	got, err := r.Parse("main")


### PR DESCRIPTION
A few things:

- Supplying `any` for the status will allow for users to restart the latest build on a given branch regardless of its status without having to enumerate all statuses
- Return `err` when failing to restart a target build
- Default depth of 50 instead of 500 for builds searching + early exiting the pagination loop if a build is found early. No need to grab 500 builds when the first one is the desired status.

Closes https://github.com/go-vela/community/issues/220
Closes https://github.com/go-vela/community/issues/981